### PR TITLE
defaultsfile option, skip information_schema database and change job status message types

### DIFF
--- a/fd-plugins/mysql-python/BareosFdMySQLclass.py
+++ b/fd-plugins/mysql-python/BareosFdMySQLclass.py
@@ -90,6 +90,8 @@ class BareosFdMySQLclass (BareosFdPluginBaseclass):
             self.databases = showDb.stdout.read().splitlines()
             if 'performance_schema' in self.databases:
                 self.databases.remove('performance_schema')
+            if 'information_schema' in self.databases:
+                self.databases.remove('information_schema')
             showDb.wait()
             returnCode = showDb.poll()
             if returnCode == None:

--- a/fd-plugins/mysql-python/BareosFdMySQLclass.py
+++ b/fd-plugins/mysql-python/BareosFdMySQLclass.py
@@ -62,6 +62,11 @@ class BareosFdMySQLclass (BareosFdPluginBaseclass):
             if not 'drop_and_recreate' in self.options or not self.options['drop_and_recreate'] == 'false':
                 self.dumpoptions += " --add-drop-database --databases "
 
+        # if defaultsfile is set
+        if 'defaultsfile' in self.options:
+            self.defaultsfile = self.options['defaultsfile']
+            self.mysqlconnect += " --defaults-file=" + self.defaultsfile
+
         if 'mysqlhost' in self.options:
             self.mysqlhost = self.options['mysqlhost']
             self.mysqlconnect += " -h " + self.mysqlhost

--- a/fd-plugins/mysql-python/BareosFdMySQLclass.py
+++ b/fd-plugins/mysql-python/BareosFdMySQLclass.py
@@ -130,7 +130,7 @@ class BareosFdMySQLclass (BareosFdPluginBaseclass):
         DebugMessage(context, 100, "Dumper: '" + dumpcommand + "'\n")
         self.stream = Popen(dumpcommand, shell=True, stdout=PIPE, stderr=PIPE)
 
-        JobMessage(context, bJobMessageType['M_DEBUG'], "Starting backup of " + savepkt.fname + "\n");
+        JobMessage(context, bJobMessageType['M_INFO'], "Starting backup of " + savepkt.fname + "\n");
         return bRCs['bRC_OK'];
 
 

--- a/fd-plugins/mysql-python/README.md
+++ b/fd-plugins/mysql-python/README.md
@@ -65,11 +65,16 @@ is used.
 You may overwrite the whole option string with parameter dumpoptions or just supress the latter two, which are needed to include drop and
 create database statements into the dump. With drop_and_recreate set to 'false', these options are skipped.
 
+##### defaultsfile option ####
+
+This parameter allows to specify a defaultsfile that shall be used for mysql(client) and mysqldump command line utilities.
+
 
 ##### Database access /  user and password  #####
 
 By default the root user (the user, which runs the Bareos filedaemon) is used to connect to the database. We recommend that you set
-a password for the user and store it in your my.cnf. You can however set a user and / or password as plugin options:
+a password for the user and store it in your my.cnf or use the defaultsfile option to point to another client configuration file.
+You can however set a user and / or password as plugin options:
 ```
 mysqluser=username:mysqlpassword=secret
 ```


### PR DESCRIPTION
Hello,

I've done some changes to the MySQL plugin which could be probably also interesting for others:
- allow specifying an --defaults-file which can contain a user and password to connect to the database. advantage instead of using the global my.cnf would be that this --defaults-file does only need to be root user readable, so access permissions to database can be kept secure.
- skip the information_schema database
- change message type of the "Starting backup of...." from debug to info

Cheers