### PR TITLE
When the record contains a starttime of '0000-00-00 00:00:00' 

### DIFF
--- a/misc/performance/graphite/bareos-graphite-poller.py
+++ b/misc/performance/graphite/bareos-graphite-poller.py
@@ -214,7 +214,7 @@ def getEvents(whereJobs):
     ...
     '''
     events = []
-    statement = """select * from Job %s""" % whereJobs
+    statement = """select * from Job %s and starttime <> '0000-00-00 00:00:00'""" % whereJobs
     logger.debug("Query db: %s" % statement)
     response = director.call(".sql query=\"%s\"" % statement)
     if 'query' in response.keys():


### PR DESCRIPTION
To avoid an error when the zero Timestamp is converted this a additional where clause is given

```
Traceback (most recent call last):
  File "/etc/bareos/bareos-graphite-poller.py", line 419, in <module>
    events = getEvents(whereJobs)# Please enter the commit message for your changes. Lines starting
  File "/etc/bareos/bareos-graphite-poller.py", line 242, in getEvents# with '#' will be ignored, and an empty message aborts the commit.
    timeObject = datetime.datetime.strptime(row['starttime'], "%Y-%m-%d %H:%M:%S")# On branch master
  File "/usr/lib/python2.7/_strptime.py", line 325, in _strptime# Your branch is up-to-date with 'origin/master'.
    (data_string, format))#
ValueError: time data '0000-00-00 00:00:00' does not match format '%Y-%m-%d %H:%M:%S'
```
HTH