### PR TITLE
Update bareos-migrate-config.sh

### DIFF
--- a/misc/bareos-migrate-config/bareos-migrate-config.sh
+++ b/misc/bareos-migrate-config/bareos-migrate-config.sh
@@ -20,7 +20,7 @@ bconsole()
   grep -v -e "$cmd" "$temp" > "$out"
 }
 
-for restype in catalog client console counter director fileset job jobdefs messages pool profile schedule storage; do
+for restype in catalog client console counter director fileset jobs jobdefs messages pool profile schedule storage; do
     printf "\n%s:\n" "$restype"
     printf "==========\n"
     mkdir $restype 2>/dev/null


### PR DESCRIPTION
Hi Jörg,
"jobs" it needs to be, otherwise it'll read the jobdefs resources again and creates a broken config.
So happened to me :)
Cheers Jan