### PR TITLE
Add escape \ to grep for dot-command

### DIFF
--- a/misc/bareos-migrate-config/bareos-migrate-config.sh
+++ b/misc/bareos-migrate-config/bareos-migrate-config.sh
@@ -17,7 +17,7 @@ bconsole()
   printf "%s\n%s\n%s\n" "gui on" "@out $temp" "$cmd" | $BCONSOLE > /dev/null
   # The send command is also written to the output. Remove it.
   # Error messages normally also contain the command, so they are also removed.
-  grep -v -e "$cmd" "$temp" > "$out"
+  grep -v -e "\$cmd" "$temp" > "$out"
 }
 
 for restype in catalog client console counter director fileset job jobdefs messages pool profile schedule storage; do


### PR DESCRIPTION
The bconsole dot-command is parsed unescaped by grep. This causes all config definitions which name ends in the restype to be filtered out of the result and not parsed for conversion (and I have a lot of those for a vmware cluster...)