### PR TITLE
replace grep with tail to prevent filtering certain configurations

### DIFF
--- a/misc/bareos-migrate-config/bareos-migrate-config.sh
+++ b/misc/bareos-migrate-config/bareos-migrate-config.sh
@@ -17,7 +17,7 @@ bconsole()
   printf "%s\n%s\n%s\n" "gui on" "@out $temp" "$cmd" | $BCONSOLE > /dev/null
   # The send command is also written to the output. Remove it.
   # Error messages normally also contain the command, so they are also removed.
-  grep -v -e "$cmd" "$temp" > "$out"
+  tail -n +2 "$temp" > "$out"
 }
 
 for restype in catalog client console counter director fileset job jobdefs messages pool profile schedule storage; do


### PR DESCRIPTION
When listing configurations using the dot-command, grep also filters all configurations which names end in the same word as the dot-command. Since the command is always the 1st line, tail can be used to select all lines except the 1st.
