### PR TITLE
Prevent BareosFdMySQL breaking if size calculation goes wrong

### DIFF
--- a/fd-plugins/mysql-python/BareosFdMySQLclass.py
+++ b/fd-plugins/mysql-python/BareosFdMySQLclass.py
@@ -137,7 +137,10 @@ class BareosFdMySQLclass (BareosFdPluginBaseclass):
 
         statp = StatPacket()
         if not size_curr_db == "NULL\n":
-            statp.size = int(size_curr_db)
+            try:
+                statp.size = int(size_curr_db)
+            except ValueError:
+                pass
         savepkt.statp = statp
         savepkt.fname = "/_mysqlbackups_/"+db+".sql"
         savepkt.type = bFileType['FT_REG']


### PR DESCRIPTION
We did observe bacula sometimes failing with the following message:

  File "/usr/lib64/bareos/plugins/BareosFdWrapper.py", line 42, in start_backup_file
    return bareos_fd_plugin_object.start_backup_file(context, savepkt)
  File "/usr/lib64/bareos/plugins/BareosFdMySQLclass.py", line 142, in start_backup_file
    statp.size = int(size_curr_db)
ValueError: invalid literal for int() with base 10: ''

This error happened due to a legacy database being backed up that did not contain the information_schema tables.
Use exceptions to catch the size conversion error and continue executing.