### PR TITLE
Persona Xtrabackup plugin fix error while LSA parsing

### DIFF
--- a/fd-plugins/bareos_percona/BareosFdPercona.py
+++ b/fd-plugins/bareos_percona/BareosFdPercona.py
@@ -209,7 +209,7 @@ class BareosFdPercona (BareosFdPluginBaseclass):
                     return bRCs['bRC_Error']
             # use old method as fallback, if module MySQLdb not available
             else:
-                get_lsn_command = ("echo 'SHOW ENGINE INNODB STATUS' | %s | grep 'Log sequence number' | cut -d ' ' -f 4"
+                get_lsn_command = ("echo 'SHOW ENGINE INNODB STATUS' | %s | grep 'Log sequence number' | tr -s [:blank:] | cut -d ' ' -f 4"
                                    % self.mysqlcmd)
                 last_lsn_proc = Popen(get_lsn_command, shell=True, stdout=PIPE, stderr=PIPE)
                 last_lsn_proc.wait()


### PR DESCRIPTION
In some mysql configuration log sequence number not parsing well, because it have more than 1 space between words and number. ->  "Log sequence number_______243545481050" (github truncates spaces)

[Example of commands](https://github.com/bareos/bareos-contrib/files/3412464/Examples.txt)

